### PR TITLE
Adding Bitcoin.com as a new Adaptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Support Bitcoin and Bitcoin Cash in your Ruby on Rails application!
 
 A rails gem that enables any model to have bitcoin payments.
 The polymorphic table bitcoin_payments creates payments with unique addresses based on a BIP32 deterministic seed using https://github.com/wink/money-tree
-and uses the (https://helloblock.io OR https://blockchain.info/) API to check for payments.
+and uses different API to check for payments.
 
 Payments have 5 states:  `pending`, `partial_payment`, `paid_in_full`, `confirmed`, `comped`
 
@@ -12,10 +12,9 @@ No private keys needed, No bitcoind blockchain indexing on new servers, just add
 
 Support for multiple fiat currencies: `USD` `EUR` `GBP` `AUD` `BRL` `CAD` `CZK` `IDR` `ILS` `JPY` `MXN` `MYR` `NZD` `PLN` `RUB` `SEK` `SGD` `TRY`
 
-Donations appreciated
-
-`142WJW4Zzc9iV7uFdbei8Unpe8WcLhUgmE`
-`bitcoincash:qqsnzsxsytmp45t6ndyaz5etj0x9vvacvqmphswqa8`
+## TODO
+* Implement Bitcoin SV
+* Find a reliable webhooks provider
 
 ## Rails 5.1
 
@@ -32,7 +31,7 @@ Master now supports multiple Rails versions.
 
 Add this line to your application's Gemfile:  (I might be too lazy to update RubyGems all the time)
 
-    gem 'bitcoin_payable', git: 'https://github.com/Sailias/bitcoin_payable', branch: 'master'
+    gem 'bitcoin_payable', git: 'https://github.com/maesitos/bitcoin_payable', branch: 'master'
 
 And then execute:
 
@@ -65,7 +64,7 @@ BitcoinPayable.config do |config|
   config.master_public_key = "your xpub master public key here"
 
   config.testnet = true
-  config.adapter = 'blocktrail' # Use blocktrail, blockchain_info or blockcypher
+  config.adapter = 'blocktrail' # Use blocktrail, blockchain_info, blockcypher or bitcoin_com
 
   # Confirmations (defaults to 6)
   config.confirmations = 6
@@ -92,6 +91,7 @@ end
 
     BitcoinPayable.config.testnet = false
 
+## Adapters
 #### Blocktrail Adapter
 
 If you use `config.adapter = 'blocktrail'` *(The only one supporting webhooks)* you'll need to set the following environment variables:
@@ -107,6 +107,18 @@ If you use `config.adapter = 'blocktrail'` *(The only one supporting webhooks)* 
 Please bear in mind [Blocktrail.com](http://blocktrail.com) was acquired by [Bitmain](http://bitmain.com) and the service has ben entirely moved to [BTC.com](http://btc.com).
 
 You can obtain your API keys at https://dev.btc.com
+
+#### Adapters status
+
+
+| Adapter         | Health        | Webhooks        | Coins Supported
+| -------------   |:-------------:| ----------:     | ---------------:|
+| Bitcoin.com     | Good          | No              | BCH
+| Blocktrail      | Dead          | Yes             | BCH and BTC
+| BTC.com         | Very Bad      | Deprecated      | BCH and BTC
+| Blockchyper     | Good          | Not implemented | BTC
+| Blockchain.info | Good          | No              | BTC
+
 
 #### Node Path
 

--- a/lib/bitcoin_payable.rb
+++ b/lib/bitcoin_payable.rb
@@ -13,6 +13,7 @@ require 'bitcoin_payable/adapters/base'
 require 'bitcoin_payable/adapters/blockchain_info_adapter'
 require 'bitcoin_payable/adapters/blockcypher_adapter'
 require 'bitcoin_payable/adapters/blocktrail_adapter'
+require 'bitcoin_payable/adapters/bitcoin_com_adapter'
 
 # Require all the interactor files
 require 'bitcoin_payable/interactors/webhook_notification_processor'

--- a/lib/bitcoin_payable/adapters/bitcoin_com_adapter.rb
+++ b/lib/bitcoin_payable/adapters/bitcoin_com_adapter.rb
@@ -1,0 +1,34 @@
+module BitcoinPayable::Adapters
+  class BitcoinComAdapter < Base
+
+    def initialize
+      raise 'An error has occured' unless BitcoinPayable.config.crypto == :bch
+      prefix = BitcoinPayable.config.testnet ? 't' : ''
+      @url = "https://#{prefix}rest.bitcoin.com/v2"
+    end
+
+    def fetch_transactions_for_address(address)
+      url = "#{@url}/address/utxo/#{address}"
+      uri = URI.parse(url)
+
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = true
+
+      request = Net::HTTP::Get.new(uri.request_uri)
+      response = http.request(request)
+
+      message = JSON.parse(response.body)
+      message['utxos'].map do |tx|
+        {
+          txHash: tx['txid'],
+          blockHash: nil,  # Not supported
+          blockTime: nil,  # Not supported
+          estimatedTxTime: nil, #Not supported
+          estimatedTxValue: tx['satoshis'],
+          confirmations: tx['confirmation'] || 0
+        }
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
Since Block-trail was acquired by Bitmain.com they have dropped the webhooks feature and overall the service has been very bad.

We have included a new adapter to continue the support for Bitcoin Cash. 

Just include `config.adapter = "bitcoin_com"` in your _**config/initializers/bitcoin_payable.rb**_ and you are good to go.